### PR TITLE
examples: use eprintln instead of stderr directly

### DIFF
--- a/examples/decrypt.rs
+++ b/examples/decrypt.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 extern crate getopts;
 extern crate gpgme;
 
@@ -14,7 +13,7 @@ use gpgme::{Context, Protocol};
 
 fn print_usage(program: &str, opts: &Options) {
     let brief = format!("Usage: {} [options] FILENAME", program);
-    write!(io::stderr(), "{}", opts.usage(&brief));
+    eprintln!("{}", opts.usage(&brief));
 }
 
 fn main() {
@@ -30,7 +29,7 @@ fn main() {
         Ok(matches) => matches,
         Err(fail) => {
             print_usage(program, &opts);
-            writeln!(io::stderr(), "{}", fail);
+            eprintln!("{}", fail);
             exit(1);
         }
     };

--- a/examples/encrypt.rs
+++ b/examples/encrypt.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 extern crate getopts;
 extern crate gpgme;
 
@@ -14,7 +13,7 @@ use gpgme::{Context, Protocol};
 
 fn print_usage(program: &str, opts: &Options) {
     let brief = format!("Usage: {} [options] FILENAME", program);
-    write!(io::stderr(), "{}", opts.usage(&brief));
+    eprintln!("{}", opts.usage(&brief));
 }
 
 fn main() {
@@ -38,7 +37,7 @@ fn main() {
         Ok(matches) => matches,
         Err(fail) => {
             print_usage(program, &opts);
-            writeln!(io::stderr(), "{}", fail);
+            eprintln!("{}", fail);
             exit(1);
         }
     };

--- a/examples/export.rs
+++ b/examples/export.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 extern crate getopts;
 extern crate gpgme;
 
@@ -13,7 +12,7 @@ use gpgme::{Context, Protocol};
 
 fn print_usage(program: &str, opts: &Options) {
     let brief = format!("Usage: {} [options] USERID+", program);
-    write!(io::stderr(), "{}", opts.usage(&brief));
+    eprintln!("{}", opts.usage(&brief));
 }
 
 fn main() {
@@ -28,7 +27,7 @@ fn main() {
         Ok(matches) => matches,
         Err(fail) => {
             print_usage(program, &opts);
-            writeln!(io::stderr(), "{}", fail);
+            eprintln!("{}", fail);
             exit(1);
         }
     };

--- a/examples/import.rs
+++ b/examples/import.rs
@@ -1,10 +1,7 @@
-#![allow(unused_must_use)]
 extern crate getopts;
 extern crate gpgme;
 
 use std::env;
-use std::io;
-use std::io::prelude::*;
 use std::process::exit;
 
 use getopts::Options;
@@ -55,7 +52,7 @@ fn print_import_result(result: gpgme::ImportResult) {
 
 fn print_usage(program: &str, opts: &Options) {
     let brief = format!("Usage: {} [options] FILENAME+", program);
-    write!(io::stderr(), "{}", opts.usage(&brief));
+    eprintln!("{}", opts.usage(&brief));
 }
 
 fn main() {
@@ -71,7 +68,7 @@ fn main() {
         Ok(matches) => matches,
         Err(fail) => {
             print_usage(program, &opts);
-            writeln!(io::stderr(), "{}", fail);
+            eprintln!("{}", fail);
             exit(1);
         }
     };

--- a/examples/keylist.rs
+++ b/examples/keylist.rs
@@ -1,10 +1,7 @@
-#![allow(unused_must_use)]
 extern crate getopts;
 extern crate gpgme;
 
 use std::env;
-use std::io;
-use std::io::prelude::*;
 use std::process::exit;
 
 use getopts::Options;
@@ -13,7 +10,7 @@ use gpgme::{Context, Protocol};
 
 fn print_usage(program: &str, opts: &Options) {
     let brief = format!("Usage: {} [options] [USERID]+", program);
-    write!(io::stderr(), "{}", opts.usage(&brief));
+    eprintln!("{}", opts.usage(&brief));
 }
 
 fn main() {
@@ -35,7 +32,7 @@ fn main() {
         Ok(matches) => matches,
         Err(fail) => {
             print_usage(program, &opts);
-            writeln!(io::stderr(), "{}", fail);
+            eprintln!("{}", fail);
             exit(1);
         }
     };

--- a/examples/sign.rs
+++ b/examples/sign.rs
@@ -1,4 +1,3 @@
-#![allow(unused_must_use)]
 extern crate getopts;
 extern crate gpgme;
 
@@ -14,7 +13,7 @@ use gpgme::{Context, Protocol};
 
 fn print_usage(program: &str, opts: &Options) {
     let brief = format!("Usage: {} [options] FILENAME", program);
-    write!(io::stderr(), "{}", opts.usage(&brief));
+    eprintln!("{}", opts.usage(&brief));
 }
 
 fn print_result(result: &gpgme::SigningResult) {
@@ -45,7 +44,7 @@ fn main() {
         Ok(matches) => matches,
         Err(fail) => {
             print_usage(program, &opts);
-            writeln!(io::stderr(), "{}", fail);
+            eprintln!("{}", fail);
             exit(1);
         }
     };
@@ -84,7 +83,7 @@ fn main() {
             let key = ctx.find_secret_key(key).unwrap();
             ctx.add_signer(&key).unwrap();
         } else {
-            writeln!(io::stderr(), "ignoring --key in UI-server mode");
+            eprintln!("ignoring --key in UI-server mode");
         }
     }
 

--- a/examples/swdb.rs
+++ b/examples/swdb.rs
@@ -2,8 +2,6 @@ extern crate getopts;
 extern crate gpgme;
 
 use std::env;
-use std::io;
-use std::io::prelude::*;
 use std::process::exit;
 
 use getopts::Options;
@@ -12,7 +10,7 @@ use gpgme::{Context, Protocol};
 
 fn print_usage(program: &str, opts: &Options) {
     let brief = format!("Usage: {} [options] [name] [version]", program);
-    let _ = write!(io::stderr(), "{}", opts.usage(&brief));
+    let _ = eprintln!("{}", opts.usage(&brief));
 }
 
 fn main() {
@@ -26,7 +24,7 @@ fn main() {
         Ok(matches) => matches,
         Err(fail) => {
             print_usage(program, &opts);
-            let _ = writeln!(io::stderr(), "{}", fail);
+            let _ = eprintln!("{}", fail);
             exit(1);
         }
     };

--- a/examples/verify.rs
+++ b/examples/verify.rs
@@ -1,11 +1,8 @@
-#![allow(unused_must_use)]
 extern crate getopts;
 extern crate gpgme;
 
 use std::env;
 use std::fs::File;
-use std::io;
-use std::io::prelude::*;
 use std::process::exit;
 
 use getopts::Options;
@@ -14,7 +11,7 @@ use gpgme::{Context, Protocol};
 
 fn print_usage(program: &str, opts: &Options) {
     let brief = format!("Usage: {} [options] [SIGFILE] FILE", program);
-    write!(io::stderr(), "{}", opts.usage(&brief));
+    eprintln!("{}", opts.usage(&brief));
 }
 
 fn print_summary(summary: gpgme::SignatureSummary) {
@@ -102,7 +99,7 @@ fn main() {
         Ok(matches) => matches,
         Err(fail) => {
             print_usage(program, &opts);
-            writeln!(io::stderr(), "{}", fail);
+            eprintln!("{}", fail);
             exit(1);
         }
     };
@@ -128,8 +125,7 @@ fn main() {
     let signature = match File::open(&matches.free[0]) {
         Ok(file) => file,
         Err(err) => {
-            writeln!(
-                io::stderr(),
+            eprintln!(
                 "{}: can't open '{}': {}",
                 program,
                 &matches.free[0],
@@ -143,8 +139,7 @@ fn main() {
         let signed = match File::open(&matches.free[1]) {
             Ok(file) => file,
             Err(err) => {
-                writeln!(
-                    io::stderr(),
+                eprintln!(
                     "{}: can't open '{}': {}",
                     program,
                     &matches.free[1],
@@ -161,7 +156,7 @@ fn main() {
     match result {
         Ok(result) => print_result(&result),
         Err(err) => {
-            writeln!(io::stderr(), "{}: verification failed: {}", program, err);
+            eprintln!("{}: verification failed: {}", program, err);
             exit(1);
         }
     }


### PR DESCRIPTION
This allows `#![allow(unused_must_use)]` to be removed.