### PR TITLE
PinentryMode Context getter by reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,7 @@ name = "verify"
 [[test]]
 name = "edit"
 
+[[test]]
+name = "context"
+
 [workspace]

--- a/src/context.rs
+++ b/src/context.rs
@@ -193,7 +193,7 @@ impl Context {
     }
 
     #[inline]
-    pub fn pinentry_mode(self) -> ::PinentryMode {
+    pub fn pinentry_mode(&self) -> ::PinentryMode {
         unsafe { ::PinentryMode::from_raw(ffi::gpgme_get_pinentry_mode(self.as_raw())) }
     }
 

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -1,0 +1,23 @@
+extern crate gpgme;
+#[macro_use]
+extern crate lazy_static;
+extern crate tempdir;
+
+use gpgme::Context;
+use gpgme::PinentryMode::Loopback;
+
+#[macro_use]
+mod support;
+
+test_case! {
+    test_pinentry_mode(test) {
+        let mode = Loopback;
+        let mut context: Context = test.create_context();
+
+        context.set_pinentry_mode(mode).expect("should work");
+
+        let context_ref: &Context = &context;
+
+        assert_eq!(mode, context_ref.pinentry_mode());
+    }
+}


### PR DESCRIPTION
Seems to be a regression (fixed first time in #10 )

Added a test to make sure it will not be re-introduced.